### PR TITLE
Improve Error Handling 

### DIFF
--- a/.profile.d/uc3-aws-util.sh
+++ b/.profile.d/uc3-aws-util.sh
@@ -29,7 +29,7 @@ get_ssm_json_by_path() {
   check_ssm_root
   P=$1
   SSMPATH="${SSM_ROOT_PATH}${P}"
-  SSMJSON=`aws ssm get-parameters-by-path --recursive --path "${SSMPATH}" --region ${REGION} | jq -r '.Parameters'`
+  SSMJSON=`aws ssm get-parameters-by-path --recursive --path "${SSMPATH}" --region ${REGION} | jq -r '.Parameters'` || die "Parameter Path ${SSMPATH} not found"
 }
 
 get_value_from_ssm_json() {

--- a/.profile.d/uc3-aws-util.sh
+++ b/.profile.d/uc3-aws-util.sh
@@ -3,7 +3,7 @@ REGION=us-west-2
 
 die() {
   echo "$*" 1>&2
-  if [ $EXIT_ON_DIE ]
+  if ($EXIT_ON_DIE)
   then
     echo "  ** Script Exiting **"
     exit 1

--- a/.profile.d/uc3-aws-util.sh
+++ b/.profile.d/uc3-aws-util.sh
@@ -3,9 +3,12 @@ REGION=us-west-2
 
 die() {
   echo "$*" 1>&2
-  if [ $EXIT_ON_DIE ]
+  if $EXIT_ON_DIE
   then
+    echo "  ** Script Exiting **"
     exit 1
+  else
+    echo "  ** Command Failed **"
   fi
 }
 

--- a/.profile.d/uc3-aws-util.sh
+++ b/.profile.d/uc3-aws-util.sh
@@ -3,12 +3,10 @@ REGION=us-west-2
 
 die() {
   echo "$*" 1>&2
-  if ($EXIT_ON_DIE)
+  if (${EXIT_ON_DIE:-false})
   then
     echo "  ** Script Exiting **"
     exit 1
-  else
-    echo "  ** Command Failed **"
   fi
 }
 
@@ -30,7 +28,7 @@ get_ssm_json_by_path() {
   P=$1
   SSMPATH="${SSM_ROOT_PATH}${P}"
   SSMJSON_RAW=`aws ssm get-parameters-by-path --recursive --path "${SSMPATH}" --region ${REGION}` || die "Parameter Path ${SSMPATH} not found"
-  SSMJSON=`echo $SSMJSON_RAW | jq -r '.Parameters'` 
+  SSMJSON=`echo $SSMJSON_RAW | jq -r '.Parameters'`
 }
 
 get_value_from_ssm_json() {

--- a/.profile.d/uc3-aws-util.sh
+++ b/.profile.d/uc3-aws-util.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 REGION=us-west-2
 
-die() { echo "$*" 1>&2 ; exit 1; }
+die() {
+  echo "$*" 1>&2
+  if [ $EXIT_ON_DIE ]
+  then
+    exit 1
+  fi
+}
 
 check_ssm_root() {
   [ $SSM_ROOT_PATH ] || die 'SSM_ROOT_PATH must be set'

--- a/.profile.d/uc3-aws-util.sh
+++ b/.profile.d/uc3-aws-util.sh
@@ -29,7 +29,8 @@ get_ssm_json_by_path() {
   check_ssm_root
   P=$1
   SSMPATH="${SSM_ROOT_PATH}${P}"
-  SSMJSON=`aws ssm get-parameters-by-path --recursive --path "${SSMPATH}" --region ${REGION} | jq -r '.Parameters'` || die "Parameter Path ${SSMPATH} not found"
+  SSMJSON_RAW=`aws ssm get-parameters-by-path --recursive --path "${SSMPATH}" --region ${REGION}` || die "Parameter Path ${SSMPATH} not found"
+  SSMJSON=`echo $SSMJSON_RAW | jq -r '.Parameters'` 
 }
 
 get_value_from_ssm_json() {

--- a/.profile.d/uc3-aws-util.sh
+++ b/.profile.d/uc3-aws-util.sh
@@ -3,7 +3,7 @@ REGION=us-west-2
 
 die() {
   echo "$*" 1>&2
-  if $EXIT_ON_DIE
+  if [ $EXIT_ON_DIE ]
   then
     echo "  ** Script Exiting **"
     exit 1

--- a/bin/uc3-mysql.sh
+++ b/bin/uc3-mysql.sh
@@ -74,7 +74,7 @@ DB_NAME=${DB_NAME:-${SSM_DB_NAME:-inv}}
 DB_ROLE=${DB_ROLE:-${SSM_DB_ROLE:-readonly}}
 
 
-if $DEBUG
+if [ $DEBUG ]
 then
   echo " -- Environment Variables --"
   echo "SSM_ROOT_PATH: ${SSM_ROOT_PATH}"

--- a/bin/uc3-mysql.sh
+++ b/bin/uc3-mysql.sh
@@ -102,7 +102,7 @@ fi
 
 # Option 2: get parameters in a single API call, save to json variable
 
-get_ssm_json_by_path "${DB_NAME}/" || die 'Cannot read database credentials from SSM'
+get_ssm_json_by_path "${DB_NAME}/" 
 
 dbname=`get_value_from_ssm_json ${DB_NAME}/db-name`
 dbhost=`get_value_from_ssm_json ${DB_NAME}/db-host`

--- a/bin/uc3-mysql.sh
+++ b/bin/uc3-mysql.sh
@@ -13,6 +13,7 @@
 # Usage:
 #   uc3-mysql.sh [db_name] [db_role] [-debug] -- [params to pass to mysql]
 
+EXIT_ON_DIE=1
 source ~/.profile.d/uc3-aws-util.sh
 
 create_ssm_path_from_tags

--- a/bin/uc3-mysql.sh
+++ b/bin/uc3-mysql.sh
@@ -74,7 +74,7 @@ DB_NAME=${DB_NAME:-${SSM_DB_NAME:-inv}}
 DB_ROLE=${DB_ROLE:-${SSM_DB_ROLE:-readonly}}
 
 
-if [ $DEBUG ]
+if ($DEBUG)
 then
   echo " -- Environment Variables --"
   echo "SSM_ROOT_PATH: ${SSM_ROOT_PATH}"

--- a/bin/uc3-mysql.sh
+++ b/bin/uc3-mysql.sh
@@ -102,7 +102,7 @@ fi
 
 # Option 2: get parameters in a single API call, save to json variable
 
-get_ssm_json_by_path "${DB_NAME}/"
+get_ssm_json_by_path "${DB_NAME}/" || die 'Cannot read database credentials from SSM'
 
 dbname=`get_value_from_ssm_json ${DB_NAME}/db-name`
 dbhost=`get_value_from_ssm_json ${DB_NAME}/db-host`

--- a/bin/uc3-mysql.sh
+++ b/bin/uc3-mysql.sh
@@ -13,7 +13,7 @@
 # Usage:
 #   uc3-mysql.sh [db_name] [db_role] [-debug] -- [params to pass to mysql]
 
-EXIT_ON_DIE=1
+EXIT_ON_DIE=true
 source ~/.profile.d/uc3-aws-util.sh
 
 create_ssm_path_from_tags


### PR DESCRIPTION
Only call `exit` from a script.  Otherwise, simply fail an operation.