### PR TITLE
set SSM_ROOT_PATH as shell env var, but only if a function is called.

### DIFF
--- a/.profile.d/uc3-aws-util.sh
+++ b/.profile.d/uc3-aws-util.sh
@@ -11,6 +11,7 @@ die() {
 }
 
 check_ssm_root() {
+  [ $SSM_ROOT_PATH ] || create_ssm_path_from_tags
   [ $SSM_ROOT_PATH ] || die 'SSM_ROOT_PATH must be set'
 }
 
@@ -60,5 +61,5 @@ create_ssm_path_from_tags() {
   PROGRAM=`get_value_from_tag_json Program`
   SERVICE=`get_value_from_tag_json Service`
   ENVIRONMENT=`get_value_from_tag_json Environment`
-  SSM_ROOT_PATH="/${PROGRAM}/${SERVICE}/${ENVIRONMENT}/"
+  export SSM_ROOT_PATH="/${PROGRAM}/${SERVICE}/${ENVIRONMENT}/"
 }


### PR DESCRIPTION
re SSM_ROOT_PATH - I think this is a nice solution. if check_ssm_root fail, call create_ssm_path_from_tags. this exports SSM_ROOT_PATH into shell env but only if needed.  don't want to query aws for tags everytime dpr2 logs in.